### PR TITLE
Add HTML structure and script wrapper

### DIFF
--- a/schedule-parser.html
+++ b/schedule-parser.html
@@ -1,3 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<script>
         async function handleFile(file) {
             if (file.type !== 'application/pdf') {
                 showErrorMessage('Παρακαλώ επιλέξτε ένα αρχείο PDF.');


### PR DESCRIPTION
## Summary
- add <!DOCTYPE html>, <html>, <head>, and <body> tags to the top of schedule parser
- wrap existing JavaScript in a script tag inside the body

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c159208c508332b037e5987bfaae18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Wrapped the page in a standard HTML5 structure so it can be opened directly in a browser; no functional changes.
  * The file currently includes two full HTML documents; browsers will render only the first, and the extra content may be ignored.
* **Chores**
  * Added a newline at the end of the file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->