### PR TITLE
Correct room extraction and add tests

### DIFF
--- a/extractCourseInfo.test.js
+++ b/extractCourseInfo.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Extract the extractCourseInfo function from the HTML file
+const html = fs.readFileSync('./schedule-parser.html', 'utf8');
+const match = html.match(/function extractCourseInfo\(line, day, timeSlots\) {([\s\S]*?)return courses;\n\s*}/);
+if (!match) {
+  throw new Error('extractCourseInfo function not found');
+}
+const script = match[0] + '\nmodule.exports = extractCourseInfo;';
+
+const context = { module: { exports: {} } };
+vm.runInNewContext(script, context);
+const extractCourseInfo = context.module.exports;
+
+// Test line with "αιθ." pattern
+const lineWithPrefix = 'ΔΟΚΙΜΗ ΜΑΘΗΜΑΤΟΣ αιθ. 101';
+const resultPrefix = extractCourseInfo(lineWithPrefix, 'ΔΕΥΤΕΡΑ', ['10:00-12:00']);
+assert.strictEqual(resultPrefix[0].room, '101');
+
+// Test line with parentheses pattern
+const lineWithParens = 'ΔΟΚΙΜΗ ΜΑΘΗΜΑΤΟΣ (202)';
+const resultParens = extractCourseInfo(lineWithParens, 'ΔΕΥΤΕΡΑ', ['10:00-12:00']);
+assert.strictEqual(resultParens[0].room, '202');
+
+console.log('All tests passed');

--- a/schedule-parser.html
+++ b/schedule-parser.html
@@ -166,8 +166,9 @@
                         let professor = professorMatch ? `${professorMatch[1]}, ${professorMatch[2]}` : 'Δεν διατίθεται';
                         
                         // Extract room
-                        const roomMatch = line.match(/αιθ\.?\s*(\w+\-?\d+|\d+)/i) || line.match(/\((\d+)\)/);
-                        let room = roomMatch ? roomMatch[0] : 'Δεν διατίθεται';
+                        const roomMatch = line.match(/αιθ\.?\s*(\w+\-?\d+|\d+)/i) || line.match(/\((\w+\-?\d+|\d+)\)/);
+                        let room = roomMatch ? roomMatch[1] : 'Δεν διατίθεται';
+                        room = room.replace(/^αιθ\.?\s*/i, '').replace(/[()]/g, '').trim();
                         
                         // Determine type
                         let type = 'lecture';


### PR DESCRIPTION
## Summary
- Fix room parsing in `extractCourseInfo` to use captured group and normalize values
- Add unit tests for room number extraction with prefix and parentheses patterns

## Testing
- `node extractCourseInfo.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c15936bfd88332a45cd6788654bbb8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room detection in the Greek schedule parser, correctly handling values with “αιθ.” prefix and rooms inside parentheses.
  * Normalizes extracted room values and maintains a sensible fallback when no room is found.

* **Tests**
  * Added unit tests covering room parsing for both “αιθ.”-prefixed and parenthesized formats.
  * Ensures consistent parsing behavior across common input variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->