### PR TITLE
Add parentheses support for room detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,7 +527,11 @@
                     if (courseName.length > 5) {
                         const professorMatch = line.match(/([Α-ΩΆ-Ώα-ωάέήίόύώ]+\.?\s+[Α-ΩΆ-Ώα-ωάέήίόύώ]+),?\s*(Καθηγητής|Επ\.\s*Καθηγητής|Αν\.\s*Καθηγητής|Λέκτορας|ΕΔΙΠ|ΥΔ|Μεταδιδάκτορας)/);
                         let professor = professorMatch ? `${professorMatch[1]}, ${professorMatch[2]}` : 'Δεν διατίθεται';
-                        const roomMatch = line.match(/αιθ\.?\s*(\w+\-?\d+|\d+)/i) || line.match(/\((\w+\-?\d+|\d+)\)/);
+                        // Support room numbers either following the "αιθ." prefix or
+                        // wrapped in parentheses with no prefix.
+                        const roomMatch =
+                            line.match(/αιθ\.?\s*(\w+\-?\d+|\d+)/i) ||
+                            line.match(/\(([^)\s]+)\)/);
                         let room = roomMatch ? roomMatch[1] : 'Δεν διατίθεται';
                         room = room.replace(/^αιθ\.?\s*/i, '').replace(/[()]/g, '').trim();
                         let type = 'lecture';


### PR DESCRIPTION
## Summary
- improve room extraction to detect numbers in parentheses or after `αιθ.` prefix

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1687005088332b3e0c7c89f103042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved recognition of room formats in Greek schedules, including values inside parentheses.
- Bug Fixes
  - Reduced missed or incorrect room entries during Greek schedule import by broadening room detection.
- Documentation
  - Clarified behavior of room parsing in Greek schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->